### PR TITLE
[Breaking change] Rename Options to match naming conventions

### DIFF
--- a/lib/membrane_element_file/sink.ex
+++ b/lib/membrane_element_file/sink.ex
@@ -1,6 +1,6 @@
 defmodule Membrane.Element.File.Sink do
   use Membrane.Element.Base.Sink
-  alias Membrane.Element.File.SinkOptions
+  alias Membrane.Element.File.Sink.Options
   alias Membrane.Buffer
 
 
@@ -12,7 +12,7 @@ defmodule Membrane.Element.File.Sink do
   # Private API
 
   @doc false
-  def handle_init(%SinkOptions{location: location}) do
+  def handle_init(%Options{location: location}) do
     {:ok, %{
       location: location,
       fd: nil

--- a/lib/membrane_element_file/sink_options.ex
+++ b/lib/membrane_element_file/sink_options.ex
@@ -1,7 +1,7 @@
-defmodule Membrane.Element.File.SinkOptions do
+defmodule Membrane.Element.File.Sink.Options do
   defstruct location: nil
 
-  @type t :: %Membrane.Element.File.SinkOptions{
+  @type t :: %Membrane.Element.File.Sink.Options{
     location: String.t
   }
 end

--- a/lib/membrane_element_file/source.ex
+++ b/lib/membrane_element_file/source.ex
@@ -1,6 +1,6 @@
 defmodule Membrane.Element.File.Source do
   use Membrane.Element.Base.Source
-  alias Membrane.Element.File.SourceOptions
+  alias Membrane.Element.File.Source.Options
   alias Membrane.Buffer
   use Membrane.Helper
 
@@ -13,7 +13,7 @@ defmodule Membrane.Element.File.Source do
   # Private API
 
   @doc false
-  def handle_init(%SourceOptions{location: location, chunk_size: size}) do
+  def handle_init(%Options{location: location, chunk_size: size}) do
     {:ok, %{
       location: location,
       chunk_size: size,

--- a/lib/membrane_element_file/source_options.ex
+++ b/lib/membrane_element_file/source_options.ex
@@ -1,9 +1,9 @@
-defmodule Membrane.Element.File.SourceOptions do
+defmodule Membrane.Element.File.Source.Options do
   defstruct \
     location: nil,
     chunk_size: 2048
 
-  @type t :: %Membrane.Element.File.SourceOptions{
+  @type t :: %Membrane.Element.File.Source.Options{
     location: String.t,
     chunk_size: pos_integer,
   }


### PR DESCRIPTION
Merging this will break every app that uses either `File.Sink` or `File.Source`, requested reviews just to let you know.