### PR TITLE
Make source send caps while handling prepared to playing

### DIFF
--- a/lib/membrane_file/source.ex
+++ b/lib/membrane_file/source.ex
@@ -6,7 +6,7 @@ defmodule Membrane.File.Source do
   use Membrane.Source
   import Mockery.Macro
 
-  alias Membrane.Buffer
+  alias Membrane.{Buffer, RemoteStream}
   alias Membrane.File.{CommonFile, Error}
 
   def_options location: [
@@ -19,7 +19,7 @@ defmodule Membrane.File.Source do
                 description: "Size of chunks being read"
               ]
 
-  def_output_pad :output, caps: :any
+  def_output_pad :output, caps: {RemoteStream, type: :packetized}
 
   @impl true
   def handle_init(%__MODULE__{location: location, chunk_size: size}) do
@@ -37,6 +37,11 @@ defmodule Membrane.File.Source do
       {:ok, fd} -> {:ok, %{state | fd: fd}}
       error -> Error.wrap(error, :open, state)
     end
+  end
+
+  @impl true
+  def handle_prepared_to_playing(_ctx, state) do
+    {{:ok, caps: {:output, %RemoteStream{type: :packetized}}}, state}
   end
 
   @impl true

--- a/lib/membrane_file/source.ex
+++ b/lib/membrane_file/source.ex
@@ -19,7 +19,7 @@ defmodule Membrane.File.Source do
                 description: "Size of chunks being read"
               ]
 
-  def_output_pad :output, caps: {RemoteStream, type: :packetized}
+  def_output_pad :output, caps: {RemoteStream, type: :bytestream}
 
   @impl true
   def handle_init(%__MODULE__{location: location, chunk_size: size}) do
@@ -41,7 +41,7 @@ defmodule Membrane.File.Source do
 
   @impl true
   def handle_prepared_to_playing(_ctx, state) do
-    {{:ok, caps: {:output, %RemoteStream{type: :packetized}}}, state}
+    {{:ok, caps: {:output, %RemoteStream{type: :bytestream}}}, state}
   end
 
   @impl true


### PR DESCRIPTION
This PR adjusts the source element to be capable of using the Membrane Core in the future 0.10.x version, where sending caps is required before the first buffer is sent. 