### PR TITLE
Update version to 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `membrane_file_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {membrane_file_plugin, "~> 0.13.1"}
+    {membrane_file_plugin, "~> 0.14.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.File.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.13.1"
+  @version "0.14.0"
 
   @github_url "https://github.com/membraneframework/membrane_file_plugin"
 


### PR DESCRIPTION
Last changes containing updating membrane_core to v0.11 should be released with version 0.14.0, not 0.13.1, so this PR fixes that 